### PR TITLE
Re-enable meta files of the MD Files to prevent errors when referencng package from OpenUPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-﻿CHANGELOG.md.meta
-README.md.meta
+﻿

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 382ea1bd09268304e8544907de809d8c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: da40fade342bd0040ac478741b5117de
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f7ca6ce96dca2bf459c4daf29bf6bcdd
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR re-enables .meta files for the following files:

* LICENSE.md
* README.md
* CHANGELOG.md

While using the package as OpenUPM reference. Unity editor tried to create meta files for these files but ended up failing as the package content was supposed to be immutable.

![image](https://user-images.githubusercontent.com/4037271/105461122-0e993d80-5c8d-11eb-8b7f-2d8278898a7a.png)
